### PR TITLE
Isolate hsi calls

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,53 @@
+from typing import Dict, List
+
+from zstash.utils import run_command
+
+
+class FakeProcess:
+    def __init__(self, returncode: int = 0):
+        self.returncode = returncode
+
+    def communicate(self):
+        return (b"", b"")
+
+
+def test_run_command_sanitizes_loader_vars_for_hsi(monkeypatch):
+    monkeypatch.setenv("HOME", "/tmp/test-home")
+    monkeypatch.setenv("LD_LIBRARY_PATH", "/tmp/pixi/lib")
+    monkeypatch.setenv("LD_PRELOAD", "/tmp/pixi/preload.so")
+
+    captured: Dict[str, Dict[str, str]] = {}
+
+    def fake_popen(command_args: List[str], **kwargs) -> FakeProcess:
+        captured["command_args"] = command_args
+        captured["env"] = kwargs["env"]
+        return FakeProcess()
+
+    monkeypatch.setattr("zstash.utils.subprocess.Popen", fake_popen)
+
+    run_command("hsi --help", "test error")
+
+    assert captured["command_args"] == ["hsi", "--help"]
+    assert "LD_LIBRARY_PATH" not in captured["env"]
+    assert "LD_PRELOAD" not in captured["env"]
+    assert captured["env"]["HOME"] == "/tmp/test-home"
+
+
+def test_run_command_keeps_loader_vars_for_non_hsi(monkeypatch):
+    monkeypatch.setenv("LD_LIBRARY_PATH", "/tmp/pixi/lib")
+    monkeypatch.setenv("LD_PRELOAD", "/tmp/pixi/preload.so")
+
+    captured: Dict[str, Dict[str, str]] = {}
+
+    def fake_popen(command_args: List[str], **kwargs) -> FakeProcess:
+        captured["command_args"] = command_args
+        captured["env"] = kwargs["env"]
+        return FakeProcess()
+
+    monkeypatch.setattr("zstash.utils.subprocess.Popen", fake_popen)
+
+    run_command("echo hello", "test error")
+
+    assert captured["command_args"] == ["echo", "hello"]
+    assert captured["env"]["LD_LIBRARY_PATH"] == "/tmp/pixi/lib"
+    assert captured["env"]["LD_PRELOAD"] == "/tmp/pixi/preload.so"

--- a/zstash/utils.py
+++ b/zstash/utils.py
@@ -12,6 +12,8 @@ from typing import Any, Dict, List, Tuple
 
 from .settings import TupleTarsRow, config, logger
 
+LOADER_SANITIZED_ENV_VARS: Tuple[str, ...] = ("LD_LIBRARY_PATH", "LD_PRELOAD")
+
 
 # Classes #####################################################################
 class DirectoryScanner:
@@ -138,9 +140,24 @@ def include_files(include: str, files: List[str]) -> List[str]:
     return filter_files(include, files, include=True)
 
 
-def run_command(command: str, error_str: str):
+def get_command_environment(command_args: List[str]) -> Dict[str, str]:
+    env: Dict[str, str] = os.environ.copy()
+
+    if command_args and command_args[0] == "hsi":
+        # Avoid inheriting pixi/conda loader overrides into the system hsi binary.
+        for env_var in LOADER_SANITIZED_ENV_VARS:
+            env.pop(env_var, None)
+
+    return env
+
+
+def run_command(command: str, error_str: str) -> None:
+    command_args: List[str] = shlex.split(command)
     p1: subprocess.Popen = subprocess.Popen(
-        shlex.split(command), stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        command_args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=get_command_environment(command_args),
     )
     stdout: bytes
     stderr: bytes


### PR DESCRIPTION
## Summary

Objectives:
- Fix `hsi` errors related to `libncurses` in Unified 1.13.0rc4 reported in #439 

Issue resolution:
- See #439 

Select one: This pull request is...
- [x] a bug fix: increment the patch version

Please fill out either the "Small Change" or "Big Change" section (the latter includes the numbered subsections), and delete the other.

## Small Change

- [x] To merge, I will use "Squash and merge". That is, this change should be a single commit.
- [x] Logic: I have visually inspected the entire pull request myself.
- [x] Pre-commit checks: All the pre-commits checks have passed.
