### PR TITLE
Fixes of unified rc5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="zstash",
-    version="1.6.0rc1",
+    version="1.6.0rc2",
     author="Ryan Forsyth, Chris Golaz, Zeshawn Shaheen",
     author_email="forsyth2@llnl.gov, golaz1@llnl.gov, shaheen2@llnl.gov",
     description="Long term HPSS archiving software for E3SM",

--- a/tbump.toml
+++ b/tbump.toml
@@ -2,7 +2,7 @@
 github_url = "https://github.com/E3SM-Project/zstash.git"
 
 [version]
-current = "1.6.0rc1"
+current = "1.6.0rc2"
 
 # Example of a semver regexp with support for PEP 440
 # release candidates.Make sure this matches current_version

--- a/tests/integration/bash_tests/run_from_perlmutter/follow_symlinks.sh
+++ b/tests/integration/bash_tests/run_from_perlmutter/follow_symlinks.sh
@@ -14,6 +14,10 @@ check_log_has()
     done
 }
 
+run_hsi() {
+    env -u LD_LIBRARY_PATH -u LD_PRELOAD hsi "$@"
+}
+
 setup()
 {
   echo "##########################################################################################################"
@@ -22,7 +26,7 @@ setup()
   case_name="${3}"
   archive_name=$4
   if [[ "${use_hpss}" == "true" ]]; then
-      hsi rm -R ${archive_name}
+      run_hsi rm -R ${archive_name}
   fi
   echo "use_hpss=${use_hpss}"
   echo "follow_symlinks=${follow_symlinks}"

--- a/tests/integration/bash_tests/run_from_perlmutter/test_update_non_empty_hpss.bash
+++ b/tests/integration/bash_tests/run_from_perlmutter/test_update_non_empty_hpss.bash
@@ -14,6 +14,10 @@ check_log_has()
     fi
 }
 
+run_hsi() {
+    env -u LD_LIBRARY_PATH -u LD_PRELOAD hsi "$@"
+}
+
 # base.setupDirs ##############################################################
 test_dir=zstash_test
 
@@ -47,7 +51,7 @@ echo "Cache:"
 ls -l ${test_dir}/${cache} 2>&1 | tee ${case_name}_cache.log
 check_log_has "index.db" ${case_name}_cache.log
 echo "HPSS:"
-hsi ls -l ${hpss_path} 2>&1 | tee ${case_name}_hpss.log
+run_hsi ls -l ${hpss_path} 2>&1 | tee ${case_name}_hpss.log
 check_log_has "000000.tar" ${case_name}_hpss.log
 check_log_has "index.db" ${case_name}_hpss.log
 
@@ -65,7 +69,7 @@ echo "Cache:"
 ls -l ${test_dir}/${cache} 2>&1 | tee ${case_name}_cache.log
 check_log_has "index.db" ${case_name}_cache.log
 echo "HPSS:"
-hsi ls -l ${hpss_path} 2>&1 | tee ${case_name}_hpss.log
+run_hsi ls -l ${hpss_path} 2>&1 | tee ${case_name}_hpss.log
 check_log_has "000000.tar" ${case_name}_hpss.log
 check_log_has "000001.tar" ${case_name}_hpss.log
 check_log_has "index.db" ${case_name}_hpss.log
@@ -81,7 +85,7 @@ echo "Cache:"
 ls -l ${test_dir}/${cache} 2>&1 | tee ${case_name}_cache.log
 check_log_has "index.db" ${case_name}_cache.log
 echo "HPSS:"
-hsi ls -l ${hpss_path} 2>&1 | tee ${case_name}_hpss.log
+run_hsi ls -l ${hpss_path} 2>&1 | tee ${case_name}_hpss.log
 check_log_has "000000.tar" ${case_name}_hpss.log
 check_log_has "000001.tar" ${case_name}_hpss.log
 check_log_has "000002.tar" ${case_name}_hpss.log
@@ -97,7 +101,7 @@ echo "Cache:"
 ls -l ${test_dir}/${cache} 2>&1 | tee ${case_name}_cache.log
 check_log_has "index.db" ${case_name}_cache.log
 echo "HPSS:"
-hsi ls -l ${hpss_path} 2>&1 | tee ${case_name}_hpss.log
+run_hsi ls -l ${hpss_path} 2>&1 | tee ${case_name}_hpss.log
 check_log_has "000000.tar" ${case_name}_hpss.log
 check_log_has "000001.tar" ${case_name}_hpss.log
 check_log_has "000002.tar" ${case_name}_hpss.log
@@ -114,7 +118,7 @@ echo "Cache:"
 ls -l ${test_dir}/${cache} 2>&1 | tee ${case_name}_cache.log
 check_log_has "index.db" ${case_name}_cache.log
 echo "HPSS:"
-hsi ls -l ${hpss_path} 2>&1 | tee ${case_name}_hpss.log
+run_hsi ls -l ${hpss_path} 2>&1 | tee ${case_name}_hpss.log
 check_log_has "000000.tar" ${case_name}_hpss.log
 check_log_has "000001.tar" ${case_name}_hpss.log
 check_log_has "000002.tar" ${case_name}_hpss.log
@@ -135,4 +139,4 @@ rm create.log
 rm create_*.log
 rm ls.log
 rm update*.log
-hsi rm -R ${hpss_path}
+run_hsi rm -R ${hpss_path}

--- a/zstash/__init__.py
+++ b/zstash/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "v1.6.0rc1"
+__version__ = "v1.6.0rc2"

--- a/zstash/globus_utils.py
+++ b/zstash/globus_utils.py
@@ -31,6 +31,7 @@ HPSS_ENDPOINT_MAP: Dict[str, str] = {
 REGEX_ENDPOINT_MAP: Dict[str, str] = {
     r"theta.*\.alcf\.anl\.gov": "08925f04-569f-11e7-bef8-22000b9a448b",
     r"beboplogin\d+.*\.lcrc\.anl\.gov": "15288284-7006-4041-ba1a-6b52501e49f1",
+    r"ilogin\d+.*\.lcrc\.anl\.gov": "15288284-7006-4041-ba1a-6b52501e49f1",
     r"blueslogin.*\.lcrc\.anl\.gov": "15288284-7006-4041-ba1a-6b52501e49f1",
     r"chrlogin.*\.lcrc\.anl\.gov": "15288284-7006-4041-ba1a-6b52501e49f1",
     r"b\d+\.lcrc\.anl\.gov": "15288284-7006-4041-ba1a-6b52501e49f1",


### PR DESCRIPTION
## Summary

Objectives:
- Note: the first two commits are from #440, and will be merged separately [EDIT: now rebased away]
- Commit 3: Bump to v1.6.0rc2
- Commits 4-5: Fixes to `hsi` calls in tests
- Commit 6: Adding Improv support

Issue resolution:
- Resolve issues encountered while testing `zstash v1.6.0` RCs (E3SM Unified 1.13.0 RCs). See [here](https://github.com/E3SM-Project/zstash/discussions/439).

Select one: This pull request is...
- [x] a bug fix: increment the patch version
- [ ] a small improvement: increment the minor version
- [ ] a new feature: increment the minor version
- [ ] an incompatible (non-backwards compatible) API change: increment the major version

## Small Change

- [ ] To merge, I will use "Squash and merge". That is, this change should be a single commit.
  - I'm actually going to use a merge commit since the commits represent distinct fixes/updates.
- [x] Logic: I have visually inspected the entire pull request myself.
- [x] Pre-commit checks: All the pre-commits checks have passed.
